### PR TITLE
Fix lists overlapping in IE11 on the Documentation page

### DIFF
--- a/src/components/list/styles.css
+++ b/src/components/list/styles.css
@@ -62,12 +62,10 @@
 
 /* type_vertical */
 .list.type_vertical {
-	counter-reset: number;
 	flex-direction: column;
 	}
 	.list.type_vertical .list__item {
-		flex-basis: 100%;
-		counter-increment: number;
+		flex-basis: auto;
 		position: relative;
 		margin-bottom: 25px;
 		}


### PR DESCRIPTION
Fixes #1

Live — https://pavelkornev.github.io/openui5-website/fix_documentation_IE11/